### PR TITLE
Add library whose name matches that of the package

### DIFF
--- a/ne2wm.el
+++ b/ne2wm.el
@@ -1,0 +1,30 @@
+;;; ne2wm.el --- TODO Describe what this package does
+
+;; Copyright (C) 2012  Takafumi Arakaki
+
+;; Author: Takafumi Arakaki
+;; Keywords: tools, window manager
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; TODO Describe what this package does.
+
+;;; Code:
+
+(require 'ne2wm-setup)
+
+(provide 'ne2wm)
+;;; ne2wm.el ends here


### PR DESCRIPTION
Every Emacs package should provide a library whose name matches that of the package.  This convention is [almost universally](https://emacsmirror.net/stats/kludges.html#org04b0b94) followed and allows users to easily find the entry point, and allows tools to extract metadata, such as the package description.

Speaking of metadata, I am unclear on what this package does, so I have used "TODO Describe what this package does" as the package summary and commentary.  Please provide that information.